### PR TITLE
Fix not found build folder when deploy vercel

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -171,6 +171,7 @@
         "{packages,apps}/src/**.tsx"
       ],
       "outputs": [
+        "**/build/**",
         "**/dist/**",
         "./apps/next/.next/**"
       ],


### PR DESCRIPTION
# Description
Fix not found build folder when deploy Vercel, the problem cause by auto deploy by github on Vercel may make Turborepo hits the cache and skips the actual build, so the build directory is not recreated and Vercel cannot find it. To handle it, we need define folder need restore when deploy when cache hit in turbo.json file. For detail information, please check this [link](https://vercel.com/kb/guide/missing-routes-manifest-or-output-turborepo-nx?utm_source=chatgpt.com)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Evidence**:

https://github.com/user-attachments/assets/856a27ce-0028-41c2-9fb5-b120fc53bf4a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules