### PR TITLE
Fix can not find v2 route for joc network

### DIFF
--- a/apps/web/src/state/routing/slice.ts
+++ b/apps/web/src/state/routing/slice.ts
@@ -179,7 +179,7 @@ export const routingApi = createApi({
             return trace.child({ name: 'Quote on client', op: 'quote.client' }, async () => {
               const { getRouter, getClientSideQuote } = await import('lib/hooks/routing/clientSideSmartOrderRouter')
               const router = getRouter(args.tokenInChainId)
-              const quoteResult = await getClientSideQuote(args, router, CLIENT_PARAMS)
+              const quoteResult = await getClientSideQuote(args, router, args.protocolPreferences ? { protocols: args.protocolPreferences } : CLIENT_PARAMS)
               if (quoteResult.state === QuoteState.SUCCESS) {
                 const trade = await transformQuoteToTrade(args, quoteResult.data, QuoteMethod.CLIENT_SIDE_FALLBACK)
                 return {


### PR DESCRIPTION
# Description
Fix can not find v2 route for JOC network by update V2_SUPPORTED chain list with JOC in Uniswap smart-order-router package

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Evidence**:

https://github.com/user-attachments/assets/b262058b-9beb-44a3-93d5-5c1c77a8a978

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules